### PR TITLE
feat(socket): Socket 1.3.2: Socket parameter WrapperClass

### DIFF
--- a/playground/socket/index.ts
+++ b/playground/socket/index.ts
@@ -6,10 +6,19 @@ import {
   Event,
   Args,
   bootstrapSocketIO,
-  Namespace
+  Namespace,
+  Socket
 } from '@decorators/socket';
 
 const server = listen(3000);
+
+class SocketWrapper {
+  constructor(private socket: SocketIO.Socket) {}
+
+  log() {
+    console.log(this);
+  }
+}
 
 @ServerMiddleware((io, socket, next) => {
   console.log('Global Server Middleware');
@@ -30,7 +39,8 @@ class FirstController {
     console.log('Message middleware');
     next();
   })
-  onMessage(@Args() message) {
+  onMessage(@Args() message, @Socket(SocketWrapper) socket: SocketWrapper) {
+    socket.log();
     console.log(`Message:  ${message}`);
   }
 

--- a/playground/socket/package.json
+++ b/playground/socket/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decorators/playground-socket",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "node decorators",
   "main": "index.js",
   "dependencies": {

--- a/socket/CHANGELOG.md
+++ b/socket/CHANGELOG.md
@@ -1,3 +1,11 @@
+# Socket#1.3.2
+* Added wrap option for **@Socket(WrapperClass?)** decorator, now you can pass wrapper class in it, to get extended functionality over the socket, optional parameter, e.g.:
+```typescript
+class SocketWrapper {
+  constructor(private socket: SocketIO.Socket) {}
+}
+```
+
 # Socket#1.3.1
 * Added callback function (noop) even if it doesn't exists, just prevent additional checks in controller
 

--- a/socket/README.md
+++ b/socket/README.md
@@ -35,7 +35,13 @@ function middleware(io: SocketIO.Server | SocketIO.Namespace, socket: SocketIO.S
 
 ##### Parameter
 * **@IO()** - returns server itself
-* **@Socket()** - returns socket
+* **@Socket(WrapperClass?: Class)** - returns socket, if **WrapperClass** provided, returns instance 
+of **WrapperClass**, passes **socket** as dependency into **WrapperClass**
+```typescript
+class SocketWrapper {
+  constructor(private socket: SocketIO.Socket) {}
+}
+```
 * **@Args()** - returns event arguments (excluding callback)(if it exists)
 * **@Callback()** - returns callback function (if it exists)
 

--- a/socket/package.json
+++ b/socket/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@decorators/socket",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "node decorators",
   "main": "index.js",
   "dependencies": {
-    "socket.io": "1.7.1"
+    "socket.io": "1.7.2"
   },
   "keywords": [
     "nodejs",

--- a/socket/src/decorators/param.ts
+++ b/socket/src/decorators/param.ts
@@ -18,7 +18,7 @@ function addParameterMeta(target: SocketIOClass, propertyKey: string | symbol, c
 /**
  * Parameter decorator factory, creates parameter decorator
  * @param parameterType Parameter Type
- * @returns {()=>ParameterDecorator}
+ * @returns { () => ParameterDecorator }
  */
 function parameterDecoratorFactory(parameterType: ParameterType): () => ParameterDecorator {
   return function(): ParameterDecorator {
@@ -30,24 +30,31 @@ function parameterDecoratorFactory(parameterType: ParameterType): () => Paramete
 
 /**
  * Returns server itself
- * @type {(name?:string)=>ParameterDecorator}
+ * @type { () => ParameterDecorator }
  */
 export const IO = parameterDecoratorFactory(ParameterType.IO);
 
 /**
  * Returns socket
- * @type {(name?:string)=>ParameterDecorator}
+ * @param WrapperClass Class, that will get plain socket object as dependency to add new functionality on top of standard one
+ * @type { (WrapperClass?: any) => ParameterDecorator }
  */
-export const Socket = parameterDecoratorFactory(ParameterType.Socket);
+export const Socket = function(WrapperClass?: any): ParameterDecorator {
+  return function (target: SocketIOClass, propertyKey: string | symbol, index: number) {
+    addParameterMeta(target, propertyKey, {
+      index, type: ParameterType.Socket, data: WrapperClass
+    });
+  };
+};
 
 /**
  * Returns event arguments (excluding callback)(if it exists)
- * @type {(name?:string)=>ParameterDecorator}
+ * @type { () => ParameterDecorator }
  */
 export const Args = parameterDecoratorFactory(ParameterType.Args);
 
 /**
  * Returns callback function (if it exists)
- * @type {(name?:string)=>ParameterDecorator}
+ * @type { () => ParameterDecorator }
  */
 export const Callback = parameterDecoratorFactory(ParameterType.Callback);

--- a/socket/src/socket.ts
+++ b/socket/src/socket.ts
@@ -6,6 +6,16 @@ import { ParameterType } from './interface';
 function noop() {}
 
 /**
+ * Get original socket, or create instance of passed WrapperClass (data)
+ * @param {ParameterConfiguration} item
+ * @param {SocketIO.Socket} socket
+ * @returns {SocketIO.Socket}
+ */
+function getSocket(item: ParameterConfiguration, socket: SocketIO.Socket) {
+  return item.data ? new item.data(socket) : socket;
+}
+
+/**
  * Extract parameters for new handler
  * @param io
  * @param socket
@@ -16,7 +26,7 @@ function noop() {}
 function extractParameters(
   io: SocketIO.Server | SocketIO.Namespace,
   socket: SocketIO.Socket,
-  params,
+  params: ParameterConfiguration[],
   eventArgs
 ): any[] {
   let args = [];
@@ -45,7 +55,7 @@ function extractParameters(
   for (let item of params) {
     switch(item.type) {
       case ParameterType.IO: args[item.index] = io; break;
-      case ParameterType.Socket: args[item.index] = socket; break;
+      case ParameterType.Socket: args[item.index] = getSocket(item, socket); break;
       case ParameterType.Args: args[item.index] = eventArgs.pop(); break;
       case ParameterType.Callback: args[item.index] = callback || noop; break;
     }

--- a/types/base.d.ts
+++ b/types/base.d.ts
@@ -2,6 +2,7 @@ interface ParameterConfiguration {
   index: number;
   type: any;
   name?: string;
+  data?: any;
 }
 
 interface Params {


### PR DESCRIPTION
# Socket#1.3.2
* Added wrap option for **@Socket(WrapperClass?)** decorator, now you can pass wrapper class in it, to get extended functionality over the socket, optional parameter, e.g.:
```typescript
class SocketWrapper {
  constructor(private socket: SocketIO.Socket) {}
}
```