### PR TITLE
chore(docs, express): Removed unnecessary deprecated symbol and cleaned up home doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,7 @@
 ![Node Decorators](https://github.com/serhiisol/node-decorators/blob/master/decorators.png?raw=true)
 
-Project implements decorators for modern tools for NodeJS like:
-- [ExpressJS]
-- [MongooseJS]
-- [Co]
-- [Socket.IO]
+Project implements decorators for modern tools for NodeJS like 
+[ExpressJS], [MongooseJS], [Co], [Socket.IO]
 
 ## Installation
 
@@ -13,21 +10,18 @@ npm install @decorators/co --save
 npm install @decorators/express --save
 npm install @decorators/mongoose --save
 npm install @decorators/socket --save
+npm install @decorators/common --save
 ```
 
 ## Example of usage
 Here's example of usage with Express framework. It uses TypeScript and `@decorators/express` package
 
 ```typescript
-import {
-  Response, Params, Controller, Get,
-  bootstrapControllers, Middleware
-} from '@decorators/express';
+import { Response, Params, Controller, Get, attachControllers } from '@decorators/express';
 
 @Controller('/')
 class UsersController {
-  @Get('/users/:id')
-  @Middleware((req, res, next) => {
+  @Get('/users/:id', (req, res, next) => {
     console.log('route middleware');
     next();
   })
@@ -37,7 +31,9 @@ class UsersController {
 }
 
 let app = express();
-bootstrapControllers(app, [UsersController]);
+
+attachControllers(app, [UsersController]);
+
 app.listen(3000);
 ```
 

--- a/express/src/decorators/controller.ts
+++ b/express/src/decorators/controller.ts
@@ -2,7 +2,6 @@ import { getMeta, getMiddleware } from '../meta';
 
 /**
  * Registers controller for base url
- * @deprecated
  * @param {string} baseUrl
  * @param {Function|Function[]} [middleware]
  * @returns {(target:Function)=>void}


### PR DESCRIPTION
This PR fixes:

1) Removed unnecessary deprecated symbol from express controller decorator (closes #24)
2) Cleaned up home doc (closes #25)

👍 