### PR TITLE
feat(common): ES5 support, Catch accepts arguments passed into decorated function

### DIFF
--- a/common/.npmignore
+++ b/common/.npmignore
@@ -2,3 +2,4 @@
 src/**/*.ts
 !src/**/*.d.ts
 index.ts
+tsconfig.json

--- a/common/CHANGELOG.md
+++ b/common/CHANGELOG.md
@@ -1,3 +1,13 @@
+# Common#1.1.0
+* Moved project back to es5
+* **@Catch()** now accepts all passed arguments of the original function and error, e.g.:
+```typescript
+@Catch((volume: number, e: Error) => {
+  // ...
+})
+sound(volume: number) {}
+```
+
 # Common#1.0.0
 * New common decorators
   * **@Log(loggerFn?: Function)**

--- a/common/README.md
+++ b/common/README.md
@@ -106,12 +106,12 @@ class Animal {
   }
 }
 ```
-* **@Catch(func: (e) => void)** - Catches unhandled error in the function, passes error in input function
+* **@Catch(func: (...args: any, e: Error) => void)** - Catches unhandled error in the function, passes all arguments came to the function with error in input function
 ```typescript
 class Animal {
-  @Catch((e) => {
+  @Catch((volume: number, e: Error) => {
     console.log(e); //ReferenceError: name is not defined...
-  });
+  })
   sound(volume: number) {
     console.log(name, ': Auuuu', volume);
   }

--- a/common/package.json
+++ b/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decorators/common",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "node decorators",
   "main": "src/index.js",
   "dependencies": {
@@ -17,7 +17,7 @@
     "url": "https://github.com/serhiiso/node-decorators/issues"
   },
   "engines": {
-    "node": "^6.3.0"
+    "node": ">=6.3.0"
   },
   "repository": {
     "type": "git",

--- a/common/src/catch.ts
+++ b/common/src/catch.ts
@@ -6,7 +6,7 @@ export function Catch(catchFn: Function) {
   return function Catch(target, key, descriptor) {
     const originalMethod = descriptor.value;
 
-    descriptor.value = function (...args) {
+    descriptor.value = function(...args) {
       try {
         let value = originalMethod.apply(this, args);
         if (value !== undefined && value.catch) {
@@ -14,9 +14,9 @@ export function Catch(catchFn: Function) {
         }
         return value;
       } catch (error) {
-        catchFn(error);
+        catchFn(...args, error);
       }
     };
 
-  }
+  };
 }

--- a/common/src/interface.ts
+++ b/common/src/interface.ts
@@ -1,0 +1,9 @@
+export interface CommonMeta {
+  parameters: {
+    [key: string]: number[];
+  };
+}
+
+export interface CommonClass extends Object {
+  __meta__: CommonMeta;
+}

--- a/common/src/meta.ts
+++ b/common/src/meta.ts
@@ -1,3 +1,5 @@
+import { CommonClass, CommonMeta } from './interface';
+
 /**
  * Get or initiate metadata on target
  * @param target

--- a/common/tsconfig.json
+++ b/common/tsconfig.json
@@ -10,21 +10,13 @@
     "noImplicitAny": false,
     "rootDir": ".",
     "sourceMap": true,
-    "target": "es6",
-    "inlineSources": true,
-    "typeRoots": ["node_modules/@types"],
-    "pretty": true
+    "target": "es5",
+    "pretty": true,
+    "lib": [
+      "es2015"
+    ]
   },
-  "exclude": [
-    "node_modules/**/*"
-  ],
-  "include": [
-    "types/**/*"
-  ],
   "files": [
-    "co/index.ts",
-    "express/index.ts",
-    "mongoose/index.ts",
-    "socket/index.ts"
+    "src/index.ts"
   ]
 }

--- a/playground/common/index.ts
+++ b/playground/common/index.ts
@@ -1,30 +1,20 @@
-import { Log, Bind } from '@decorators/common';
+import { Catch } from '@decorators/common';
 
-@Log()
 class Animal {
 
   constructor(
     public name: string
   ) {}
 
-  @Bind()
+  @Catch((volume: number, err: Error) => {
+    console.log(volume);
+    console.log(err);
+  })
   sound(volume: number) {
-    console.log(this.name, ': Auuuu', volume);
+    throw new Error(volume.toString());
   }
 
 }
 
 let rabbit: Animal = new Animal('Rabbit');
-
-function exec(fn, arg) {
-  //some heavy logic
-  return fn(arg);
-}
-
-
-
-rabbit.sound = function () {
-  console.log(this.name);
-};
-
-exec(rabbit.sound, 500);
+rabbit.sound(10);

--- a/types/common.d.ts
+++ b/types/common.d.ts
@@ -1,9 +1,0 @@
-interface CommonMeta {
-  parameters: {
-    [key: string]: number[];
-  };
-}
-
-interface CommonClass extends Object {
-  __meta__: CommonMeta;
-}


### PR DESCRIPTION
This PR implements:

* Moved project back to es5
* **@Catch()** now accepts all passed arguments of the original function and error (closes #31), e.g.:
```typescript
@Catch((volume: number, e: Error) => {
  // ...
})
sound(volume: number) {}
```

👍 