### PR TITLE
Define types field to package.json

### DIFF
--- a/express/package.json
+++ b/express/package.json
@@ -3,6 +3,7 @@
   "version": "2.0.0",
   "description": "node decorators",
   "main": "src/index.js",
+  "types": "src/index.d.ts",
   "dependencies": {
     "express": ">=4.16.2",
     "@decorators/di": ">=1.0.0"


### PR DESCRIPTION
This should fix typescript complaining `[ts] Cannot find module '@decorators/express'.`