### PR TITLE
feat(express): Injectable as an option for controller, fix for error middleware

### DIFF
--- a/express/CHANGELOG.md
+++ b/express/CHANGELOG.md
@@ -1,8 +1,13 @@
-# Express#2.0.0
+# 2.2.0
+* `@Injectable` from `@decorators/di` is now optional for controller.
+Note: make sure to use `@Injectable` if you need dependency injection in controller
+* Fixed passing incorrect error object to next handler in case if `ERROR_MIDDLEWARE` wasn't registered
+
+# 2.1.0
 * Fixed definitions
 * Fixed complition for VSCode, etc.
 
-# Express#2.0.0
+# 2.0.0
 * Dependency injection with `@decorators/di`, closes #54;
 * Express route middlewares as a class, closes #55;
 * Functions as middleware are no longer supported, use classes instead
@@ -13,27 +18,27 @@
 * Removed deprecated methods and decorators
 * big refactoring
 
-# Express#1.3.0
+# 1.3.0
 * Moved express-related types to package interfaces
-* **@Request(name?: string)** decorator accepts optional parameter name
+* `@Request(name?: string)` decorator accepts optional parameter name
 * Controller DI
 
-# Express#1.2.0
-* Added controller-based middleware - **@Controller(baseUrl: string, [middleware]?)**
-* moved route-based middleware to route definition decorator - **@Get(url: string, [middleware]?)**
-* renamed **bootstrapControllers** to **attachControllers**
-* **@Middleware** moved to deprecated, will be removed in 2.0.0
-* **bootstrapControllers** moved to deprecated, will be removed in 2.0.0
+# 1.2.0
+* Added controller-based middleware - `@Controller(baseUrl: string, [middleware]?)`
+* moved route-based middleware to route definition decorator - `@Get(url: string, [middleware]?)`
+* renamed `bootstrapControllers` to `attachControllers`
+* `@Middleware` moved to deprecated, will be removed in 2.0.0
+* `bootstrapControllers` moved to deprecated, will be removed in 2.0.0
 
-# Express#1.1.1
-* Added possibility to pass array of middleware funcs into **@Middleware**
+# 1.1.1
+* Added possibility to pass array of middleware funcs into `@Middleware`
 
-# Express#1.1.0
+# 1.1.0
 * Automatic definitions generation
 * removed helper functions
-  * **bootstrapExpress**
-  *  **bootstrapController**
-  * **bootstrapControllersFromDirectory**
+  * `bootstrapExpress`
+  *  `bootstrapController`
+  * `bootstrapControllersFromDirectory`
 
 # 1.0.0
 * Moved project to scoped packages
@@ -41,18 +46,18 @@
 npm install @decorators/express --save
 ```
 
-# Express#0.2.4
+# 0.2.4
 * Two new ways to register controller(s) - ```bootstrapController```, ```bootstrapControllers```
 * Added missing typings for ```bootstrapControllersFromDirectory```
 
 # 0.2.2
 * Fixed typings and dev build configuration
 
-# Express#0.2.1
-* New express function **bootstrapControllersFromDirectory(app: Express, folder: string)** for reading folder with controllers
+# 0.2.1
+* New express function `bootstrapControllersFromDirectory(app: Express, folder: string)` for reading folder with controllers
 
 # 0.2.0
-* moved project to **ES6**
+* moved project to `ES6`
 
 # 0.1.4
 * Fixed express decorators request method assignment
@@ -68,7 +73,7 @@ homeAction(req, res, next) {
 ```
 
 # 0.1.1
-* added trash files into **.npmignore**
+* added trash files into `.npmignore`
 
 # 0.1.0
 * New imports:
@@ -76,13 +81,13 @@ homeAction(req, res, next) {
 import { Controller } from 'node-decorators/express';
 ```
   * Removed deprecated methods
-    * **decorateExpressApp**
-    * **App**
+    * `decorateExpressApp`
+    * `App`
 
 # 0.0.8
 * ES6 support as target
 
-# Express#0.0.5
+# 0.0.5
 ### Features
 * Base express decorators
   * Class

--- a/express/package.json
+++ b/express/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decorators/express",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "node decorators",
   "main": "src/index.js",
   "dependencies": {

--- a/express/src/express.ts
+++ b/express/src/express.ts
@@ -29,7 +29,7 @@ export function attachControllers(app: Express, controllers: Type[]) {
  * @returns
  */
 function registerController(app: Application, Controller: Type) {
-  const controller: ExpressClass = Container.get(Controller);
+  const controller: ExpressClass = getController(Controller);
   const meta: ExpressMeta = getMeta(controller);
   const router: Router = Router();
 
@@ -88,7 +88,7 @@ function errorMiddlewareHandler(): ErrorRequestHandler {
     try {
       const errorMiddleware: ErrorMiddleware = Container.get(ERROR_MIDDLEWARE);
       errorMiddleware.use(error, req, res, next);
-    } catch (error) {
+    } catch {
       next(error);
     }
   }
@@ -143,6 +143,21 @@ function extractParameters(req: Request, res: Response, next: NextFunction, para
   }
 
   return args;
+}
+
+/**
+ * Get controller instance from container or instantiate one
+ *
+ * @param {any} Controller
+ *
+ * @returns {ExpressClass}
+ */
+function getController(Controller: Type): ExpressClass {
+  try {
+    return Container.get(Controller);
+  } catch {
+    return new Controller();
+  }
 }
 
 /**

--- a/express/src/middleware.ts
+++ b/express/src/middleware.ts
@@ -39,7 +39,7 @@ export function middlewareHandler(middleware: Type): RequestHandler {
 
     try {
       instance = Container.get(middleware);
-    } catch (e) {
+    } catch {
       instance = new middleware();
     }
 

--- a/playground/express/index.ts
+++ b/playground/express/index.ts
@@ -36,15 +36,11 @@ class UserMiddleware implements Middleware {
 }
 
 @Controller('/')
-@Injectable()
 class UserController {
 
-  constructor(@Inject(MESSAGE) private message: string) {}
-
-  @Get('/user', [UserMiddleware])
+  @Get('/', [UserMiddleware])
   public getData(@Response() res): void {
-    throw Error('User test error');
-    // res.send(this.message);
+    res.send('Hello User');
   }
 
 }
@@ -58,4 +54,4 @@ Container.provide([
 
 attachControllers(app, [ UserController ]);
 
-app.listen(3003);
+app.listen(3000);

--- a/playground/express/package.json
+++ b/playground/express/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@decorators/playground-express",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "node decorators",
   "main": "index.js",
   "dependencies": {
     "@types/express": "4.0.39",
-    "@decorators/di": "1.0.0",
+    "@decorators/di": "1.0.1",
     "@decorators/express": "file:../../express"
   },
   "keywords": [


### PR DESCRIPTION
This PR fixes:

* `@Injectable` from `@decorators/di` is now optional for controller.
Note: make sure to use `@Injectable` if you need dependency injection in controller.
Closes #70 
* Fixed passing incorrect error object to next handler in case if `ERROR_MIDDLEWARE` wasn't registered