### PR TITLE
[express] Fixes `getParam` to always return property of `param` when `name` is provided

### DIFF
--- a/express/CHANGELOG.md
+++ b/express/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.2.2
+* Fixed `getParam` to always return property of `param` when `name` is provided
+
 # 2.2.1
 * Router support for `attachControllers` helper function
 * Global error middleware also intercepts errors in async method handlers

--- a/express/package.json
+++ b/express/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decorators/express",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "node decorators",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/express/src/express.ts
+++ b/express/src/express.ts
@@ -177,5 +177,5 @@ function getController(Controller: Type): ExpressClass {
 function getParam(source: any, paramType: string, name: string): any {
   let param = source[paramType] || source;
 
-  return param[name] || param;
+  return name ? param[name] : param;
 }


### PR DESCRIPTION
I had the following issue, which lead me to open this PR:

JSON payload example:
```json
{ "active": false, "appDomainId": 0 }
```

Extract of my code:
```typescript
@Controller('/user')
export default class UserController 
{
  @Post('/create')
  async create (@Response() res, @Body('active') active: boolean, @Body('appDomainId') appDomainId: number, @Body('data') data: any)
  {
    console.log(active); // returned complete body { "active": false, "appDomainId": 0 }. Expected false
    console.log(appDomainId); // returned complete body { "active": false, "appDomainId": 0 }. Expected 0

    if (data)
    {
      // It always end up here, even if data is undefined.
    }
  }
}
```