### PR TITLE
fix(express) Return `undefined` if the source does not contain the requested property.

### DIFF
--- a/express/CHANGELOG.md
+++ b/express/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.2.3
+* Fixed `getParam` to return `undefined` if `name` is not a property of `param`.
+
 # 2.2.2
 * Fixed `getParam` to always return property of `param` when `name` is provided
 

--- a/express/package.json
+++ b/express/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decorators/express",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": "node decorators",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/express/src/express.ts
+++ b/express/src/express.ts
@@ -177,5 +177,5 @@ function getController(Controller: Type): ExpressClass {
 function getParam(source: any, paramType: string, name: string): any {
   let param = source[paramType] || source;
 
-  return name ? param[name] : param;
+  return name ? param[name] : undefined;
 }


### PR DESCRIPTION
We found this when using the `Query` decorator:
```
  @Get('/')
  async list(@Query('days') days = '5', @Res() res: Response) {
    console.log('days:', days);
  }
```
- When `days` is provided (`?days=5), the output is correct: `days: 5`
- When `days` is not provided, the output is: `days: {}`
- When `days` is not provided but another property is provided (`?months=3`) : `days: { months: '3' }`

I'm not sure if any of the other uses of `getParam` rely on the source object being returned in case the requested property is missing, though..