### PR TITLE
Keep middlewares in controllers and routes meta if already set

### DIFF
--- a/express/package.json
+++ b/express/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decorators/express",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "node decorators - decorators for express library",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/express/src/decorators/controller.ts
+++ b/express/src/decorators/controller.ts
@@ -7,6 +7,7 @@ import { Type } from '../middleware';
  * Registers controller for base url
  *
  * @param {string} url
+ * @param routerOptions
  * @param {Type[]} [middleware]
  */
 export function Controller(url: string, routerOptions?: Type[] | RouterOptions, middleware?: Type[]) {
@@ -14,7 +15,7 @@ export function Controller(url: string, routerOptions?: Type[] | RouterOptions, 
     const meta: ExpressMeta = getMeta(target.prototype);
 
     meta.url = url;
-    meta.middleware = Array.isArray(routerOptions) ? routerOptions : middleware;
+    meta.middleware = Array.isArray(routerOptions) ? routerOptions.concat(meta.middleware) : middleware.concat(meta.middleware);
     meta.routerOptions = Array.isArray(routerOptions) ? null : routerOptions;
   };
 }

--- a/express/src/decorators/controller.ts
+++ b/express/src/decorators/controller.ts
@@ -7,15 +7,23 @@ import { Type } from '../middleware';
  * Registers controller for base url
  *
  * @param {string} url
+ * @param {Type[]} [middleware]
+ */
+export function Controller(url: string, middleware?: Type[]);
+/**
+ * Registers controller for base url
+ *
+ * @param {string} url
  * @param routerOptions
  * @param {Type[]} [middleware]
  */
-export function Controller(url: string, routerOptions?: Type[] | RouterOptions, middleware?: Type[]) {
+export function Controller(url: string, routerOptions?: RouterOptions, middleware?: Type[]);
+export function Controller(url: string, middlewareOrRouterOptions?: Type[] | RouterOptions, middleware: Type[] = []) {
   return (target): void => {
     const meta: ExpressMeta = getMeta(target.prototype);
 
     meta.url = url;
-    meta.middleware = Array.isArray(routerOptions) ? routerOptions.concat(meta.middleware) : middleware.concat(meta.middleware);
-    meta.routerOptions = Array.isArray(routerOptions) ? null : routerOptions;
+    meta.middleware = Array.isArray(middlewareOrRouterOptions) ? middlewareOrRouterOptions.concat(meta.middleware ?? []) : middleware.concat(meta.middleware ?? []);
+    meta.routerOptions = Array.isArray(middlewareOrRouterOptions) ? null : middlewareOrRouterOptions;
   };
 }

--- a/express/src/decorators/route.ts
+++ b/express/src/decorators/route.ts
@@ -8,11 +8,18 @@ import { Type } from '../middleware';
  * @param {string} url
  * @param {Type[]} middleware
  */
-function decoratorFactory(method: string, url: string, middleware: Type[]) {
+function decoratorFactory(method: string, url: string, middleware?: Type[]) {
+  middleware = middleware ?? [];
+
   return (target: any, key: string, descriptor: any) => {
     const meta: ExpressMeta = getMeta(target);
 
-    meta.routes[key] = { method, url, middleware };
+    if (!meta.routes[key]) {
+      meta.routes[key] = { method, url, middleware };
+    } else {
+      // Replace method and route but concatenate middlewares from previous route
+      meta.routes[key] = { method, url, middleware: middleware.concat(meta.routes[key].middleware) };
+    }
 
     return descriptor;
   };

--- a/express/src/decorators/route.ts
+++ b/express/src/decorators/route.ts
@@ -8,9 +8,7 @@ import { Type } from '../middleware';
  * @param {string} url
  * @param {Type[]} middleware
  */
-function decoratorFactory(method: string, url: string, middleware?: Type[]) {
-  middleware = middleware ?? [];
-
+function decoratorFactory(method: string, url: string, middleware: Type[] = []) {
   return (target: any, key: string, descriptor: any) => {
     const meta: ExpressMeta = getMeta(target);
 


### PR DESCRIPTION
This is useful if, for example, another annotation wants to set some middlewares on the route or controller. A use case I wanted is adding a `@Validator(...)` annotation which wraps express-validator middlewares and error handling before a controller or route annotation.
It might also be desirable to export `meta.ts` if this is something the library wants to allow the users to do.