### PR TITLE
feat(di): update reflect-metadata to 0.1.13

### DIFF
--- a/di/CHANGELOG.md
+++ b/di/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.0.3
+* Update `reflect-metadata` to 0.1.13
+
 # 1.0.2
 * Fixed cyclic di and error
 

--- a/di/package.json
+++ b/di/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decorators/di",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "node decorators - decorators for dependency injection",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/di/package.json
+++ b/di/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "dependencies": {
-    "reflect-metadata": "0.1.10"
+    "reflect-metadata": "0.1.13"
   },
   "devDependencies": {
     "@types/mocha": "2.2.44",


### PR DESCRIPTION
I'm trying to make a update of reflect-metadata due to https://github.com/serhiisol/node-decorators/issues/108, but not sure how to manage the updated "@decorators/di" for express and socket packages, hope can this help :)