### PR TITLE
feat(express): added shorter version of Request(Req) and Response(Res) decorators

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,33 @@ attachControllers(app, [UsersController]);
 app.listen(3000);
 ```
 
+
+## Another Example of usage
+In this example we are using shorter version of Request and Response decorators to typecast them with express Request and Response type.
+```typescript
+import { Req, Res, Params, Controller, Get, attachControllers } from '@decorators/express';
+import {Request,Response} from 'express';
+import { Injectable } from '@decorators/di';
+
+@Controller('/')
+@Injectable()
+class UsersController {
+
+  constructor(userService: UserService) {}
+
+  @Get('/users/:id')
+  getData(@Req() req : Request, @Res() res : Response, @Params('id') id: string) {
+    res.send(this.userService.findById(id));
+  }
+}
+
+let app: Express = express();
+
+attachControllers(app, [UsersController]);
+
+app.listen(3000);
+```
+
 ## Documentation
 Look at the corresponding package for instructions
 

--- a/express/src/decorators/params.ts
+++ b/express/src/decorators/params.ts
@@ -6,8 +6,8 @@ import { ExpressMeta, ParameterType, getMeta } from '../meta';
  * @param {ParameterType} parameterType Parameter Type
  */
 function decoratorFactory(type: ParameterType) {
-  return function(name?: string): ParameterDecorator {
-    return function(target: any, methodName: string, index: number) {
+  return function (name?: string): ParameterDecorator {
+    return function (target: any, methodName: string, index: number) {
       const meta: ExpressMeta = getMeta(target);
 
       if (meta.params[methodName] === undefined) {
@@ -25,9 +25,19 @@ function decoratorFactory(type: ParameterType) {
 export const Request = decoratorFactory(ParameterType.REQUEST);
 
 /**
+ * Express req object in short form
+ */
+export const Req = Request;
+
+/**
  * Express res object
  */
 export const Response = decoratorFactory(ParameterType.RESPONSE);
+
+/**
+ * Express res object in short form
+ */
+export const Res = Response;
 
 /**
  * Express next function


### PR DESCRIPTION
I have exported two constants Req and Res which are pointing to original full version constants Request and Response , this will eliminate the hassle of adding alias for Request and Response  decorators in imports and also not create any issues with older code which is using full name of Req and Res decorators. 

I have also added  a example in readme.md file to better understand the modification.
