### PR TITLE
fix(express-openapi): fixed Openapi package caused by express 2.8.0 update

### DIFF
--- a/express-openapi/package.json
+++ b/express-openapi/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@decorators/express-openapi",
-  "version": "1.0.0-beta",
+  "version": "1.0.1-beta",
   "description": "node decorators - openapi decorators for swagger-ui-express and @decorators/express",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "peerDependencies": {
     "express": ">=4.16.3",
-    "@decorators/di": ">=1.0.2",
-    "@decorators/express": ">=2.5.0",
-    "swagger-ui-express": ">=4.1.6"
+    "@decorators/di": ">=1.0.3",
+    "@decorators/express": ">=2.8.0",
+    "swagger-ui-express": ">=4.6.0"
   },
   "devDependencies": {
     "@decorators/di": ">=1.0.2",

--- a/express-openapi/src/decorators/WithDefinitions.ts
+++ b/express-openapi/src/decorators/WithDefinitions.ts
@@ -46,8 +46,7 @@ export function WithDefinitions(options: WithDefinitionsOpts): ClassDecorator {
 // for each method get all associated routes
 function getRoutes(routes: any, methodName: string) {
   const route = routes[methodName];
-  if (!route) return [];
-  return [route];
+  return route.routes ? route.routes : [];
 }
 
 function getPathName(basePath: string, url: string) {
@@ -75,7 +74,7 @@ function isDeprecated(url: string, pathMeta: PathMeta): boolean {
   return Array.isArray(pathMeta.deprecated) && pathMeta.deprecated.indexOf(url) >= 0;
 }
 
-const ExpressParamType: {[key: number]: ParamLocation} = {
+const ExpressParamType: { [key: number]: ParamLocation } = {
   2: 'path',
   3: 'query',
   5: 'header',
@@ -83,12 +82,12 @@ const ExpressParamType: {[key: number]: ParamLocation} = {
 };
 
 function getRouteParams(params: { type: number, name?: string }[]): ParamDef[] {
- return params
-   .filter(({ type, name }) => ExpressParamType[type] && name)
-   .map(({ type, name }) => ({ name, in: ExpressParamType[type], required: ExpressParamType[type] === 'path' }));
+  return params
+    .filter(({ type, name }) => ExpressParamType[type] && name)
+    .map(({ type, name }) => ({ name, in: ExpressParamType[type], required: ExpressParamType[type] === 'path' }));
 }
 
-function getParameters(meta: PathMeta, routeParams: ParamDef[] = []): ParamDef[]{
+function getParameters(meta: PathMeta, routeParams: ParamDef[] = []): ParamDef[] {
   const parameters = meta.parameters || [];
   routeParams.forEach(param => {
     if (parameters.findIndex(p => p.name === param.name && p.in === param.in) < 0) {


### PR DESCRIPTION
openapi decorator was crashing because WithDefinitions was using getRoutes function to extract routes as  array however due to  recent changes in express decorators  it was receiving undefined on each iterated key.