### PR TITLE
fix(express): fixed issue where server sends the response even if controller did not return anything

### DIFF
--- a/express/src/express.ts
+++ b/express/src/express.ts
@@ -81,14 +81,14 @@ function routeHandler(controller: ExpressClass, methodName: string, params: Para
 
     if (result instanceof Promise) {
       result.then((r: any) => {
-        if (!res.headersSent) {
+        if (!res.headersSent && typeof r !== 'undefined') {
           if (status) {
             res.status(status);
           }
           res.send(r);
         }
       }).catch(next);
-    } else {
+    } else if (typeof result !== 'undefined') {
       if (!res.headersSent) {
         if (status) {
           res.status(status);


### PR DESCRIPTION
When a controller was not returning  anything or returning a promise which resolves with undefined value server was sending blank response  which is fixed in this commit by adding return value check. 
