### PR TITLE
feat(express-openapi): security and global responses

### DIFF
--- a/express-openapi/package-lock.json
+++ b/express-openapi/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@decorators/express-openapi",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@decorators/express-openapi",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MIT",
       "devDependencies": {
         "@decorators/di": "../di",

--- a/express-openapi/package.json
+++ b/express-openapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decorators/express-openapi",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "node decorators - openapi decorators for swagger-ui-express and @decorators/express",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/express-openapi/readme.md
+++ b/express-openapi/readme.md
@@ -37,6 +37,8 @@ Initiates the openapi document and attaches it to the application.
 | options.externalDocs | `object` | <ul><li>optional</li></ul> | External documents definition following the openapi specifications. |
 | options.externalDocs.url | `string` | | |
 | options.externalDocs.description | `string` | <ul><li>optional</li></ul> | |
+| options.security | `object[]` | <ul><li>optional</li></ul> | Security schemes to be applied to the api |
+| options.components.securitySchemes | `object` | <ul><li>optional</li></ul> | An object that represents the `components.securitySchemes` on the openapi document. For more info see https://swagger.io/docs/specification/authentication/ |
 
 <hr>
 
@@ -71,6 +73,8 @@ Enables openapi definitions for a controller class (using `@Controller()` from `
 | ---- |----- | --------- | ----------- |
 | options | `object` |  |  |
 | options.tags | `string[]` | <ul><li>optional</li></ul> | Tags to be applied to all routes on the controller |
+| options.security | `object[]` | <ul><li>optional</li></ul> | Security schemes to be applied to all routes on the controller |
+| options.responses | `object` | <ul><li>optional</li></ul> | Tags to be applied to all routes on the controller |
 | options.basePath | `string` |  | The base path for all routes on the controller |
 
 <hr>
@@ -247,7 +251,7 @@ Defines the description for a response
 
 | Name | Type | Attribute | Description |
 | ---- |----- | --------- | ----------- |
-| status | `string | number` |  | The response status |
+| status | `string \| number` |  | The response status |
 | description | `string` |  | The description |
 
 <hr>
@@ -262,9 +266,24 @@ Defines one response schema for the operation
 
 | Name | Type | Attribute | Description |
 | ---- |----- | --------- | ----------- |
-| status | `string` `number` |  | The response status |
+| status | `string \| number` |  | The response status |
 | produces | `string` |  | The media type described |
 | schema | `object` |  | A schema definition following the openapi specifications |
+
+<hr>
+
+```ts
+@Security(schemeName: string, scopes?: string[])
+```
+
+Applies a security scheme to the operation
+
+**Params:**
+
+| Name | Type | Attribute | Description |
+| ---- | ---- | --------- | ----------- |
+| schemeName | `string` |  | The scheme name |
+| scopes | `string[]` | <ul><li>optional</li></ul> | list of required scopes |
 
 <hr>
 

--- a/express-openapi/src/decorators/path.ts
+++ b/express-openapi/src/decorators/path.ts
@@ -67,3 +67,14 @@ export function OpenApiResponse(status: string | number, descriptionOrProduces: 
     return descriptor;
   }
 }
+export function Security(schemeName: string, scopes?: string[]): MethodDecorator {
+  return (target: any, method: string, descriptor: any) => {
+    const meta = getOpenApiMeta(target);
+    const methodMeta = meta[method] = meta[method] || {};
+    const security = methodMeta.security = methodMeta.security || [];
+    security.push({
+      [schemeName]: scopes || []
+    });
+    return descriptor;
+  }
+}

--- a/express-openapi/src/helpers.ts
+++ b/express-openapi/src/helpers.ts
@@ -35,6 +35,11 @@ export async function enableOpenApi(app: Express, options: OpenApiOptions = {}) 
     tags: options.tags,
     servers: options.servers,
     externalDocs: options.externalDocs,
+    security: options.security,
+  });
+  
+  Object.assign(doc.components, {
+    securitySchemes: options.components?.securitySchemes
   });
 
   // setup swagger UI

--- a/express-openapi/src/types.ts
+++ b/express-openapi/src/types.ts
@@ -60,6 +60,56 @@ export type Properties = {
   [key: string]: SchemaDef;
 }
 
+export type StandardHttpSecurityScheme = {
+  type: "http";
+  scheme: "basic" | "digest" | "hoba" | "mutual" | "negotiate" | "oauth" | "scram-sha-1" | "scram-sha-256" | "vapid";
+}
+
+export type BearerHttpSecurityScheme = {
+  type: "http";
+  scheme: "bearer";
+  bearerFormat?: "JWT" | Omit<string, "JWT">;
+}
+
+export type HttpSecurityScheme = StandardHttpSecurityScheme | BearerHttpSecurityScheme;
+
+export type ApiKeySecurityScheme = {
+  type: "apiKey";
+  in: "header" | "query" | "cookie";
+  name: string;
+}
+
+export type OpenIdConnectSecurityScheme = {
+  type: "openIdConnect";
+  openIdConnectUrl: string;
+}
+
+export type OAuth2SecuritySchemeFlowBase = {
+  refreshUrl?: string;
+  scopes: { [scope: string]: string };
+}
+
+export type OAuth2SecurityScheme = {
+  type: "oauth2";
+  flows: {
+    authorizationCode?: OAuth2SecuritySchemeFlowBase & {
+      authorizationUrl: string;
+      tokenUrl: string;
+    };
+    implicit?: OAuth2SecuritySchemeFlowBase & {
+      authorizationUrl: string;
+    };
+    password?: OAuth2SecuritySchemeFlowBase & {
+      tokenUrl: string;
+    };
+    clientCredentials?: OAuth2SecuritySchemeFlowBase & {
+      tokenUrl: string;
+    }
+  };
+}
+
+export type SecurityScheme = HttpSecurityScheme | ApiKeySecurityScheme | OpenIdConnectSecurityScheme | OAuth2SecurityScheme;
+
 export type OpenApiOptions = {
   serveOnPath?: string;
   info?: {
@@ -70,6 +120,10 @@ export type OpenApiOptions = {
   tags?: { name: string, description?: string }[];
   servers?: { url: string, description?: string }[];
   externalDocs?: { url: string, description?: string; };
+  security?: PathSecurity;
+  components?: {
+    securitySchemes?: { [schemeName: string]: SecurityScheme };
+  };
 }
 
 export type ParamLocation = 'query' | 'header' | 'path' | 'cookie';
@@ -101,6 +155,8 @@ export type ResponseDescriptor = {
   content: Content;
 }
 
+export type PathResponses = { [httpStatus: string]: ResponseDescriptor }
+
 export type PathMeta = {
   summary?: string;
   description?: string;
@@ -108,8 +164,11 @@ export type PathMeta = {
   tags?: string[];
   deprecated?: true | string[],
   requestBody?: RequestBody;
-  responses?: { [httpStatus: string]: ResponseDescriptor };
+  responses?: PathResponses;
+  security?: PathSecurity;
 }
+
+export type PathSecurity = Array<{ [schemeName: string]: string[] }>
 
 export type OpenApiMeta = {
   [methodName: string]: PathMeta;


### PR DESCRIPTION
* add `options.security` to `enableOpenApi()`
* add `options.components.securitySchemes` to `enableOpenApi()`
* add `options.security` to `@WithDefinitions()`
* add `options.responses` to `@WithDefinitions()`
* add `@Security()` method decorator
* fix route parameter format when generating doc