### PR TITLE
feat(di): provided in root option

### DIFF
--- a/di/package-lock.json
+++ b/di/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@decorators/di",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@decorators/di",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "license": "MIT",
       "dependencies": {
         "reflect-metadata": "^0.1.13"

--- a/di/package.json
+++ b/di/package.json
@@ -42,5 +42,5 @@
     "test": "jest"
   },
   "types": "lib/index.d.ts",
-  "version": "3.0.1"
+  "version": "3.1.0"
 }

--- a/di/src/container.spec.ts
+++ b/di/src/container.spec.ts
@@ -3,6 +3,7 @@ import { Container } from './container';
 import { InjectionToken } from './injection-token';
 import { Injectable, Inject } from './decorators';
 import { InvalidDependencyError, MissingDependencyError, RecursiveDependencyError } from './errors';
+import { RootContainer } from './root-container';
 
 describe('Container', () => {
   let extraContainer: Container;
@@ -111,7 +112,7 @@ describe('Container', () => {
   describe('ClassProvider', () => {
     it('registers a provider', async () => {
       @Injectable()
-      class TestInjectable {}
+      class TestInjectable { }
 
       container.provide([
         { provide: TestInjectable, useClass: TestInjectable },
@@ -122,10 +123,10 @@ describe('Container', () => {
 
     it('replaces a provider', async () => {
       @Injectable()
-      class TestInjectable {}
+      class TestInjectable { }
 
       @Injectable()
-      class AnotherInjectable {}
+      class AnotherInjectable { }
 
       container.provide([
         { provide: TestInjectable, useClass: TestInjectable },
@@ -251,7 +252,7 @@ describe('Container', () => {
 
     it('registers a provider for existing class', async () => {
       @Injectable()
-      class TestInjectable {}
+      class TestInjectable { }
 
       const token = new InjectionToken('token');
 
@@ -293,7 +294,7 @@ describe('Container', () => {
       const token = new InjectionToken('token');
 
       @Injectable()
-      class TestInjectable {}
+      class TestInjectable { }
 
       container.provide([
         { provide: token, useClass: TestInjectable, multi: true },
@@ -312,7 +313,7 @@ describe('Container', () => {
       const token = new InjectionToken('token');
 
       @Injectable()
-      class TestInjectable {}
+      class TestInjectable { }
 
       container.provide([
         { provide: token, useValue: 1, multi: true },
@@ -343,5 +344,14 @@ describe('Container', () => {
 
       expect(await container.get(token)).toEqual(1);
     });
+  });
+});
+
+describe('RootContainer', () => {
+  it('registers a provider in RootContainer', async () => {
+    @Injectable({ providedIn: 'root' })
+    class TestInjectable { }
+
+    expect(await RootContainer.has(TestInjectable)).toBeTruthy();
   });
 });

--- a/di/src/decorators/injectable.ts
+++ b/di/src/decorators/injectable.ts
@@ -18,13 +18,13 @@ export function Injectable(options?: InjectableOptions) {
       return ids[index] ?? depId;
     });
 
+    Reflect.defineMetadata(DEP_IDS_METADATA, verifiedIds, target);
+
     if (options?.providedIn === 'root') {
       RootContainer.provide([{
         provide: target,
         useClass: target,
       }]);
     }
-
-    Reflect.defineMetadata(DEP_IDS_METADATA, verifiedIds, target);
   };
 }

--- a/di/src/decorators/injectable.ts
+++ b/di/src/decorators/injectable.ts
@@ -1,7 +1,13 @@
 import { ClassConstructor } from '../types';
 import { DEP_IDS_METADATA } from '../constants';
 
-export function Injectable() {
+import { RootContainer } from '../root-container';
+
+interface InjectableOptions {
+  providedIn?: 'root';
+}
+
+export function Injectable(options?: InjectableOptions) {
   return (target: ClassConstructor) => {
     const params = Reflect.getMetadata('design:paramtypes', target) ?? [];
     const ids = Reflect.getMetadata(DEP_IDS_METADATA, target) ?? [];
@@ -11,6 +17,13 @@ export function Injectable() {
 
       return ids[index] ?? depId;
     });
+
+    if (options?.providedIn === 'root') {
+      RootContainer.provide([{
+        provide: target,
+        useClass: target,
+      }]);
+    }
 
     Reflect.defineMetadata(DEP_IDS_METADATA, verifiedIds, target);
   };

--- a/di/src/index.ts
+++ b/di/src/index.ts
@@ -1,7 +1,6 @@
 import 'reflect-metadata';
-import { Container } from './container';
 
-export const RootContainer = new Container();
+export { RootContainer } from './root-container';
 export { Container } from './container';
 export { Injectable, Inject, Optional } from './decorators';
 export { InjectionToken } from './injection-token';

--- a/di/src/root-container.ts
+++ b/di/src/root-container.ts
@@ -1,0 +1,3 @@
+import { Container } from './container';
+
+export const RootContainer = new Container();


### PR DESCRIPTION
### Why:
To simplify root singleton providers `Injectable.providedIn='root'`.

### What was changed (if possible, include any code snippets, videos, screenshots, or gifs):

Introduces `Injectable` options with `providedIn='root'` option in it to register root provider.

`RootContainer` is exported out of `di` package.