### PR TITLE
feat(server): provided in root injectables

### DIFF
--- a/server/example/app.module.ts
+++ b/server/example/app.module.ts
@@ -4,12 +4,10 @@ import { HttpModule } from '@server/http';
 
 import { MiscModule, PostsModule } from './modules';
 import { ServerPipe } from './pipes';
-import { ServicesModule } from './services';
 
 @Module({
   modules: [
     HttpModule.create(ExpressAdapter),
-    ServicesModule,
     MiscModule,
     PostsModule,
   ],

--- a/server/example/services/index.ts
+++ b/server/example/services/index.ts
@@ -1,2 +1,1 @@
 export { PostsService } from './posts.service';
-export { ServicesModule } from './services.module';

--- a/server/example/services/posts.service.ts
+++ b/server/example/services/posts.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@server';
 
-@Injectable()
+@Injectable({ providedIn: 'root' })
 export class PostsService {
   getPosts() {
     return [

--- a/server/example/services/services.module.ts
+++ b/server/example/services/services.module.ts
@@ -1,8 +1,0 @@
-import { Module } from '@server';
-
-import { PostsService } from './posts.service';
-
-@Module({
-  providers: [PostsService],
-})
-export class ServicesModule { }

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@decorators/server",
-  "version": "1.0.0-beta.6",
+  "version": "1.0.0-beta.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@decorators/server",
-      "version": "1.0.0-beta.6",
+      "version": "1.0.0-beta.7",
       "license": "MIT",
       "devDependencies": {
         "@decorators/di": "../di",
@@ -35,7 +35,7 @@
         "typescript": "^5.0.3"
       },
       "peerDependencies": {
-        "@decorators/di": "^3.0.1",
+        "@decorators/di": "^3.1.0",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.0",
         "reflect-metadata": "^0.1.13"

--- a/server/package.json
+++ b/server/package.json
@@ -44,7 +44,7 @@
   "license": "MIT",
   "name": "@decorators/server",
   "peerDependencies": {
-    "@decorators/di": "^3.0.1",
+    "@decorators/di": "^3.1.0",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.0",
     "reflect-metadata": "^0.1.13"
@@ -69,5 +69,5 @@
       ]
     }
   },
-  "version": "1.0.0-beta.6"
+  "version": "1.0.0-beta.7"
 }

--- a/server/src/core/application.ts
+++ b/server/src/core/application.ts
@@ -1,4 +1,4 @@
-import { InjectionToken } from '@decorators/di';
+import { InjectionToken, RootContainer } from '@decorators/di';
 
 import { ContainerManager, ModuleResolver, ROOT_MODULE } from './helpers';
 import { DEFAULT_PROVIDERS } from './providers';
@@ -8,6 +8,8 @@ export class Application {
   static async create(rootModule: ClassConstructor) {
     const containerManger = new ContainerManager();
     const container = containerManger.create(Application);
+
+    container.setParent(RootContainer);
 
     container.provide([
       {


### PR DESCRIPTION
### Why:
To simplify root singleton providers via `@Injectable({ providedIn: 'root' })`.

### What was changed (if possible, include any code snippets, videos, screenshots, or gifs):

Added `RootContainer` as parent to application container.